### PR TITLE
chore: Use operator namespace when reading the TLS secret

### DIFF
--- a/controllers/user_controller.go
+++ b/controllers/user_controller.go
@@ -409,7 +409,6 @@ func (r *UserReconciler) ensureJWTSecretUpToDate(ctx context.Context, usr *v1alp
 }
 
 func (r *UserReconciler) getCAIfExists(ctx context.Context, acc *v1alpha1.Account) ([]byte, error) {
-	sClient := r.CoreV1.Secrets(acc.Namespace)
 	logger := log.FromContext(ctx)
 
 	if acc.Status.OperatorRef == nil {
@@ -430,7 +429,7 @@ func (r *UserReconciler) getCAIfExists(ctx context.Context, acc *v1alpha1.Accoun
 		return nil, errInternalNotFound
 	}
 
-	s, err := sClient.Get(ctx, op.Spec.TLSConfig.CAFile.Name, metav1.GetOptions{})
+	s, err := r.CoreV1.Secrets(op.Namespace).Get(ctx, op.Spec.TLSConfig.CAFile.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/user_controller.go
+++ b/controllers/user_controller.go
@@ -431,6 +431,10 @@ func (r *UserReconciler) getCAIfExists(ctx context.Context, acc *v1alpha1.Accoun
 
 	s, err := r.CoreV1.Secrets(op.Namespace).Get(ctx, op.Spec.TLSConfig.CAFile.Name, metav1.GetOptions{})
 	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Error(err, "could not find secret")
+			return nil, errInternalNotFound
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
This `sClient := r.CoreV1.Secrets(acc.Namespace)` was reading the operator TLS secret from the namespace of the account. 

This change updates it to look at the namespace for the operator instead. 