### PR TITLE
Push  all accounts JWT to nats

### DIFF
--- a/controllers/account_controller.go
+++ b/controllers/account_controller.go
@@ -28,6 +28,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+
 	"github.com/nats-io/nats.go"
 	"github.com/versori-oss/nats-account-operator/controllers/resources"
 	"github.com/versori-oss/nats-account-operator/pkg/helpers"
@@ -178,13 +179,8 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		return ctrl.Result{}, err
 	}
 
-	if !helpers.IsSystemAccount(acc, operator) {
-		if err := r.ensureJWTPushed(ctx, acc, operator, issuerKP, accountJWT); err != nil {
-			return ctrl.Result{}, err
-		}
-	} else {
-		// system accounts need the condition to be set to true to enable them to be considered "ready"
-		acc.Status.MarkJWTPushed()
+	if err := r.ensureJWTPushed(ctx, acc, operator, issuerKP, accountJWT); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil


### PR DESCRIPTION
We are getting the following errors using the operator 
`[31] 2023/08/08 08:24:28.181313 [ERR] Merging resulted in error: open /jwt/ACXZK2UBLOLQYBD4XH5CD4UFQMTYZKL2OF2FEGEHJXXUTIUM5U6FUPMB.jwt: no such file or directory`

and it seems the system account JWT is not pushed. 