### PR TITLE
Vp 149 fix update comparison of status

### DIFF
--- a/controllers/account_controller.go
+++ b/controllers/account_controller.go
@@ -28,14 +28,12 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nkeys"
 	"github.com/versori-oss/nats-account-operator/api/accounts/v1alpha1"
 	"github.com/versori-oss/nats-account-operator/controllers/resources"
-	"github.com/versori-oss/nats-account-operator/pkg/apis"
 	accountsclientsets "github.com/versori-oss/nats-account-operator/pkg/generated/clientset/versioned/typed/accounts/v1alpha1"
 	"github.com/versori-oss/nats-account-operator/pkg/helpers"
 	"github.com/versori-oss/nats-account-operator/pkg/nsc"
@@ -856,43 +854,6 @@ func (r *AccountReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	if err != nil {
 		return err
-	}
-
-	return nil
-}
-
-func statusEquals(old, new v1alpha1.AccountStatus) bool {
-	if !reflect.DeepEqual(old.KeyPair, new.KeyPair) {
-		return false
-	}
-
-	if !reflect.DeepEqual(old.OperatorRef, new.OperatorRef) {
-		return false
-	}
-
-	for _, con := range old.Conditions {
-		s := getStatus(new, string(con.Type))
-
-		// missing status so we have to update
-		if s == nil {
-			return false
-		}
-
-		if s.Status != con.Status && s.Reason != con.Reason && s.Message != con.Message {
-			return false
-		}
-
-	}
-
-	return true
-}
-
-func getStatus(acc v1alpha1.AccountStatus, conditionType string) *apis.Condition {
-	for _, con := range acc.Conditions {
-		if string(con.Type) == conditionType {
-			return &con
-		}
-
 	}
 
 	return nil

--- a/controllers/operator_controller.go
+++ b/controllers/operator_controller.go
@@ -29,28 +29,25 @@ import (
 	"context"
 	"time"
 
-	"go.uber.org/multierr"
-
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nkeys"
 	"github.com/versori-oss/nats-account-operator/api/accounts/v1alpha1"
 	accountsclientsets "github.com/versori-oss/nats-account-operator/pkg/generated/clientset/versioned/typed/accounts/v1alpha1"
+	"go.uber.org/multierr"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 // OperatorReconciler reconciles a Operator object
@@ -92,7 +89,7 @@ func (r *OperatorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 	operator.Status.InitializeConditions()
 
 	defer func() {
-		if !equality.Semantic.DeepEqual(originalStatus, operator.Status) {
+		if !equality.Semantic.DeepEqual(*originalStatus, operator.Status) {
 			if err2 := r.Status().Update(ctx, operator); err2 != nil {
 				logger.Info("failed to update operator status", "error", err2.Error())
 

--- a/controllers/signingkey_controller.go
+++ b/controllers/signingkey_controller.go
@@ -88,7 +88,7 @@ func (r *SigningKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	signingKey.Status.InitializeConditions()
 
 	defer func() {
-		if !equality.Semantic.DeepEqual(originalStatus, signingKey.Status) {
+		if !equality.Semantic.DeepEqual(*originalStatus, signingKey.Status) {
 			if err2 := r.Status().Update(ctx, signingKey); err2 != nil {
 				logger.Error(err2, "failed to update signing key status")
 

--- a/controllers/user_controller.go
+++ b/controllers/user_controller.go
@@ -79,7 +79,7 @@ func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resul
 	usr.Status.InitializeConditions()
 
 	defer func() {
-		if !equality.Semantic.DeepEqual(originalStatus, usr.Status) {
+		if !equality.Semantic.DeepEqual(*originalStatus, usr.Status) {
 			if err2 := r.Status().Update(ctx, usr); err2 != nil {
 				logger.Info("failed to update user status", "error", err2.Error())
 

--- a/controllers/user_controller_test.go
+++ b/controllers/user_controller_test.go
@@ -1,0 +1,81 @@
+package controllers
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/versori-oss/nats-account-operator/api/accounts/v1alpha1"
+	"github.com/versori-oss/nats-account-operator/pkg/apis"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+// this test is written to demonstrate status equality
+func Test_UserStatus_Compare(t *testing.T) {
+	timeNow := time.Now()
+
+	usr1 := v1alpha1.User{
+		Status: v1alpha1.UserStatus{
+			Status: v1alpha1.Status{
+				Conditions: apis.Conditions{
+					{
+						Type:     apis.ConditionReady,
+						Status:   corev1.ConditionTrue,
+						Severity: apis.ConditionSeverityError,
+						LastTransitionTime: apis.VolatileTime{
+							Inner: metav1.NewTime(timeNow),
+						},
+						Reason:  "test",
+						Message: "test",
+					},
+				},
+			},
+			KeyPair: &v1alpha1.KeyPair{
+				PublicKey:      "public",
+				SeedSecretName: "seed",
+			},
+			AccountRef: &v1alpha1.InferredObjectReference{
+				Namespace: "ns",
+				Name:      "name",
+			},
+		},
+	}
+
+	usr2 := v1alpha1.User{
+		Status: v1alpha1.UserStatus{
+			Status: v1alpha1.Status{
+				Conditions: apis.Conditions{
+					{
+						Type:     apis.ConditionReady,
+						Status:   corev1.ConditionTrue,
+						Severity: apis.ConditionSeverityError,
+						LastTransitionTime: apis.VolatileTime{
+							// set different time to check if equality works
+							Inner: metav1.NewTime(timeNow.Add(time.Second)),
+						},
+						Reason:  "test",
+						Message: "test",
+					},
+				},
+			},
+			KeyPair: &v1alpha1.KeyPair{
+				PublicKey:      "public",
+				SeedSecretName: "seed",
+			},
+			AccountRef: &v1alpha1.InferredObjectReference{
+				Namespace: "ns",
+				Name:      "name",
+			},
+		},
+	}
+
+	if equality.Semantic.DeepEqual(&usr1.Status, usr2.Status) {
+		t.Error("expected usr1.Status != usr2.Status")
+	}
+
+	if !equality.Semantic.DeepEqual(usr1.Status, usr2.Status) {
+		t.Error("expected usr1.Status == usr2.Status")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -27,9 +27,10 @@ package main
 
 import (
 	"flag"
+	"os"
+
 	"github.com/versori-oss/nats-account-operator/pkg/nsc"
 	"go.uber.org/zap/zapcore"
-	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -83,12 +84,13 @@ func main() {
 	cfg := ctrl.GetConfigOrDie()
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:                 scheme,
-		MetricsBindAddress:     metricsAddr,
-		Port:                   9443,
-		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "c79b9c27.accounts.nats.io",
+		Scheme:                  scheme,
+		MetricsBindAddress:      metricsAddr,
+		Port:                    9443,
+		HealthProbeBindAddress:  probeAddr,
+		LeaderElection:          enableLeaderElection,
+		LeaderElectionNamespace: "nats-io",
+		LeaderElectionID:        "c79b9c27.accounts.nats.io",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly


### PR DESCRIPTION
We had an issue where the operator was getting into a reconciliation loop. I am not sure what the exact trigger was but based on the audit logs in k8s the method that ha seen an increase was `io.nats.accounts.v1alpha1.users.status.update` which led me to believe that the status checks were incorrect and causing a reconciliation loop. 

While testing this is as not able to validate it properly against a cluster because I was not sure how to trigger the reconciliation loop. However, I added a test to demonstrate that comparing a pointer to status and status was wrong in a unit test. 

